### PR TITLE
V2 - Rebranding - Gethelp is not displayed in header

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,7 +1,9 @@
 <!-- Copyright The Linux Foundation and each contributor to CommunityBridge.
  SPDX-License-Identifier: MIT -->
 <app-loader></app-loader>
-<lfx-header product="LF CLA" id="lfx-header" [expanded]="hasExpanded" (toggled)="onToggled()">
+<lfx-header product="LF CLA" docslink="https://docs.linuxfoundation.org/docs/communitybridge/easycla"
+    supportlink="https://jira.linuxfoundation.org/plugins/servlet/theme/portal/4/create/143" id="lfx-header"
+    [expanded]="hasExpanded" (toggled)="onToggled()">
 </lfx-header>
 
 <div [ngClass]="{'expanded':hasExpanded}" class="fix-header-margin">


### PR DESCRIPTION

![Screenshot from 2020-10-30 16-12-31](https://user-images.githubusercontent.com/56335654/97695896-c540b400-1aca-11eb-8afd-e017456c24fe.png)


Signed-off-by: Amol Sontakke <amols@proximabiz.com>