### PR TITLE
[#2088] fix redirection links

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,7 +5,7 @@ import {Component} from '@angular/core';
 import {AppSettings} from './config/app-settings';
 import {LfxHeaderService} from './shared/services/lfx-header.service';
 import {EnvConfig} from './config/cla-env-utils';
-
+import { environment } from '../environments/environment';
 
 @Component({
   selector: 'app-root',
@@ -32,11 +32,11 @@ export class AppComponent {
     this.links = [
       {
         title: 'Project Login',
-        url: EnvConfig[AppSettings.PROJECT_CONSOLE_LINK],
+        url: environment.PROJECT_CONSOLE,
       },
       {
         title: 'CLA Manager Login',
-        url: EnvConfig[AppSettings.CORPORATE_CONSOLE_LINK],
+        url: environment.CORPORATE_CONSOLE,
       },
       {
         title: 'Developer',


### PR DESCRIPTION
## Overview
V2 - contributor console - User is redirected to V1 consoles when clicked in CLA links in the header
Note: Fix environment path variables.

## Ticket
[2088](https://app.zenhub.com/workspaces/easyclav2-5ed619832c71a855a76ef404/issues/communitybridge/easycla/2088)
Signed-off-by: tejas <tejas.adgaonkar@proximabiz.com>