### PR TITLE
Resolved Yarn Lib Ini Vulnerability

### DIFF
--- a/edge/package.json
+++ b/edge/package.json
@@ -21,5 +21,8 @@
     "babel-loader": "^7.1.2",
     "jasmine": "^3.1.0",
     "webpack": "^4.43.0"
+  },
+  "resolutions": {
+    "ini": "^1.3.7"
   }
 }

--- a/edge/yarn.lock
+++ b/edge/yarn.lock
@@ -1733,10 +1733,10 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.4, ini@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+ini@^1.3.4, ini@^1.3.5, ini@^1.3.7:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 interpret@^1.4.0:
   version "1.4.0"

--- a/package.json
+++ b/package.json
@@ -98,6 +98,9 @@
     "tslint": "~6.1.0",
     "typescript": "~3.9.6"
   },
+  "resolutions": {
+    "ini": "^1.3.7"
+  },
   "husky": {
     "hooks": {
       "pre-push": "yarn eslint --quiet"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6510,10 +6510,10 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@1.3.5, ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+ini@1.3.5, ini@^1.3.4, ini@^1.3.5, ini@^1.3.7, ini@~1.3.0:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 inquirer-autocomplete-prompt@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
- The ini npm package before version 1.3.6 has a Prototype Pollution
vulnerability. Updated to 1.3.7, See GHSA-qqgx-2p2h-9c37.

Signed-off-by: David Deal <dealako@gmail.com>