### PR TITLE
When designating someone else to be a CLA Manager in the contributor console, it doesn't allow a period ('.') in the name

### DIFF
--- a/src/app/config/app-settings.ts
+++ b/src/app/config/app-settings.ts
@@ -33,7 +33,7 @@ export class AppSettings {
     public static COMPANY_NAME_REGEX = '^([\\w\\d\\s\\-\\,\\./]+)$';
     public static URL_PATTERN = /^((http|https):\/\/)?(www.)?[a-zA-Z0-9-]+(\.[a-zA-Z]{2,}){1,3}(#?\/?[a-zA-Z0-9#-]+)*\/?(\?[a-zA-Z0-9-_]+=[a-zA-Z0-9-%]+&?)?$/;
     public static NON_WHITE_SPACE_REGEX = /.*\S.*/;
-    public static USER_FIRST_LAST_NAME_REGEX = /^[a-zA-Z]+(([',. -][a-zA-Z])?[a-zA-Z]*)*$/;
+    public static USER_FIRST_LAST_NAME_REGEX = /^[a-zA-Z]+(([',. -][a-zA-Z ])?[a-zA-Z.]*)*$/;
     public static GITHUB_EMAIL_CONTENT = 'noreply.github.com';
     public static NEW_ORGANIZATIONS = 'newOrganizations';
     public static LEARN_MORE = 'https://docs.linuxfoundation.org/docs/communitybridge/easycla';


### PR DESCRIPTION


Signed-off-by: Amol Sontakke <amols@proximabiz.com>