### PR TITLE
Add support for /v4/user-from-token in FE - to be connected where needed later

### DIFF
--- a/src/app/core/models/user.ts
+++ b/src/app/core/models/user.ts
@@ -19,6 +19,27 @@ export class UserModel {
     version: string;
 }
 
+export class UserFromTokenModel {
+  userID: string;
+  userExternalID?: string;
+  username?: string;
+  dateCreated?: string | Date;
+  dateModified?: string | Date;
+  lfEmail?: string;
+  lfUsername?: string;
+  companyID?: string;
+  githubID?: string;
+  githubUsername?: string;
+  gitlabID?: string;
+  gitlabUsername?: string;
+  admin?: boolean;
+  version?: string;
+  note?: string;
+  emails?: string[];
+  userCompanyID?: string;
+  isSanctioned?: boolean;
+}
+
 export class UpdateUserModel {
     companyID: string;
     dateCreated: Date;

--- a/src/app/core/services/cla-contributor.service.ts
+++ b/src/app/core/services/cla-contributor.service.ts
@@ -60,6 +60,11 @@ export class ClaContributorService {
     return this.httpClient.get<UserModel>(url);
   }
 
+  getUserFromToken(): Observable<UserFromTokenModel> {
+    const url = this.getV4Endpoint('/v4/user-from-token');
+    return this.httpClient.get<UserFromTokenModel>(url);
+  }
+
   updateUser(data: any): Observable<UpdateUserModel> {
     const url = this.getV3Endpoint('/v3/users');
     return this.httpClient.put<UpdateUserModel>(url, data);

--- a/src/app/shared/components/project-title/project-title.component.ts
+++ b/src/app/shared/components/project-title/project-title.component.ts
@@ -64,6 +64,19 @@ export class ProjectTitleComponent implements AfterViewInit {
     }
   }
 
+  getUserFromToken() {
+    this.claContributorService.getUserFromToken().subscribe(
+      (response) => {
+        this.user = response;
+        this.storageService.setItem(AppSettings.USER_ID, this.user.userID);
+        this.storageService.setItem(AppSettings.USER, this.user);
+      },
+      (exception) => {
+        this.errorEmitter.emit(true);
+        this.claContributorService.handleError(exception);
+      }
+    );
+  }
 
   getUser() {
     const userId = JSON.parse(this.storageService.getItem(AppSettings.USER_ID));


### PR DESCRIPTION
cc @mlehotskylf @thakurveerendras @amolsontakke3576 - this adds FE code to call `/v4/user-from-token` API - to be used by FE when no user UUID is specified in path (as discussed earlier).
