### PR TITLE
fix: add Osano cookie consent CSP permissions

### DIFF
--- a/edge/security-headers.js
+++ b/edge/security-headers.js
@@ -43,7 +43,8 @@ function generateCSP(env, isDevServer) {
     'https://api.lfcla.dev.platform.linuxfoundation.org/',
     'https://easycla.dev.communitybridge.org/',
     'https://easycla.lfx.linuxfoundation.org/',
-    'https://contributor.easycla.lfx.linuxfoundation.org/'
+    'https://contributor.easycla.lfx.linuxfoundation.org/',
+    'https://cmp.osano.com' // Cookie consent management
   ];
   let scriptSources = [SELF, UNSAFE_EVAL, UNSAFE_INLINE,
     'https://cdn.dev.platform.linuxfoundation.org/lfx-header-v2.js',
@@ -54,7 +55,8 @@ function generateCSP(env, isDevServer) {
     'https://cdn.dev.platform.linuxfoundation.org/lfx-footer-no-zone.js',
     'https://cdn.staging.platform.linuxfoundation.org/lfx-footer-no-zone.js',
     'https://cdn.platform.linuxfoundation.org/lfx-footer-no-zone.js',
-    'https://cmp.osano.com' // Cookie consent
+    'https://cmp.osano.com', // Cookie consent
+    'https://www.googletagmanager.com' // Google Tag Manager for Osano
   ];
 
   const styleSources = [SELF, UNSAFE_INLINE, 'https://use.fontawesome.com/', 'https://communitybridge.org/'];
@@ -106,7 +108,8 @@ function generateCSP(env, isDevServer) {
       'https://linuxfoundation-dev.auth0.com',
       'https://linuxfoundation-staging.auth0.com',
       'https://linuxfoundation.auth0.com',
-      'https://sso.linuxfoundation.org/'
+      'https://sso.linuxfoundation.org/',
+      'https://cmp.osano.com' // Cookie consent UI iframe
     ],
     'child-src': [],
     'media-src': [],

--- a/edge/security-headers.js
+++ b/edge/security-headers.js
@@ -44,7 +44,12 @@ function generateCSP(env, isDevServer) {
     'https://easycla.dev.communitybridge.org/',
     'https://easycla.lfx.linuxfoundation.org/',
     'https://contributor.easycla.lfx.linuxfoundation.org/',
-    'https://cmp.osano.com' // Cookie consent management
+    'https://cmp.osano.com', // Cookie consent management
+    'https://www.google-analytics.com', // Google Analytics beacons
+    'https://analytics.google.com', // Google Analytics 4
+    'https://www.googletagmanager.com', // GTM fetch requests
+    'https://googleads.g.doubleclick.net', // DoubleClick advertising
+    'https://stats.g.doubleclick.net' // DoubleClick stats
   ];
   let scriptSources = [SELF, UNSAFE_EVAL, UNSAFE_INLINE,
     'https://cdn.dev.platform.linuxfoundation.org/lfx-header-v2.js',

--- a/edge/security-headers.js
+++ b/edge/security-headers.js
@@ -48,7 +48,6 @@ function generateCSP(env, isDevServer) {
     'https://www.google-analytics.com', // Google Analytics beacons
     'https://analytics.google.com', // Google Analytics 4
     'https://www.googletagmanager.com', // GTM fetch requests
-    'https://googleads.g.doubleclick.net', // DoubleClick advertising
     'https://stats.g.doubleclick.net' // DoubleClick stats
   ];
   let scriptSources = [SELF, UNSAFE_EVAL, UNSAFE_INLINE,


### PR DESCRIPTION
- Add cmp.osano.com to connect-src for configuration API calls
- Add cmp.osano.com to frame-src for consent UI iframe
- Add www.googletagmanager.com to script-src for GTM integration

Resolves CSP violations preventing Osano cookie consent from functioning properly.

Signed-off-by: ahmedomosanya <aopeyemi@contractor.linuxfoundation.org>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated security settings to allow additional trusted sources for cookie consent management and analytics services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->