### PR TITLE
fix: add Segment CDN domains to CSP for LFX Segments Analytics

### DIFF
--- a/edge/security-headers.js
+++ b/edge/security-headers.js
@@ -51,7 +51,8 @@ function generateCSP(env, isDevServer) {
     'https://stats.g.doubleclick.net', // DoubleClick stats
     'https://lfx-segment.dev.platform.linuxfoundation.org', // LFX Segments Analytics (dev)
     'https://lfx-segment.platform.linuxfoundation.org', // LFX Segments Analytics (prod)
-    'https://api.segment.io' // Segment Analytics API
+    'https://api.segment.io', // Segment Analytics API
+    'https://cdn.segment.com', // Segment CDN for configurations
   ];
   let scriptSources = [SELF, UNSAFE_EVAL, UNSAFE_INLINE,
     'https://cdn.dev.platform.linuxfoundation.org/lfx-header-v2.js',
@@ -65,7 +66,8 @@ function generateCSP(env, isDevServer) {
     'https://cmp.osano.com', // Cookie consent
     'https://www.googletagmanager.com', // Google Tag Manager for Osano
     'https://lfx-segment.dev.platform.linuxfoundation.org', // LFX Segments Analytics (dev)
-    'https://lfx-segment.platform.linuxfoundation.org' // LFX Segments Analytics (prod)
+    'https://lfx-segment.platform.linuxfoundation.org', // LFX Segments Analytics (prod)
+    'https://cdn.segment.com' // Segment CDN for scripts and configurations
   ];
 
   const styleSources = [SELF, UNSAFE_INLINE, 'https://use.fontawesome.com/', 'https://communitybridge.org/'];


### PR DESCRIPTION
- Add https://cdn.segment.com to connect-src and script-src
- Resolves CSP violation errors when loading analytics configurations
- Enables proper initialization of LFX Segments Analytics library
- Maintains security while allowing necessary analytics functionality

Fixes CSP error: 'Refused to connect to https://cdn.segment.com/v1/projects/.../settings'

Addresses: https://github.com/linuxfoundation/easycla/issues/4790
Signed-off-by: ahmedomosanya <aopeyemi@contractor.linuxfoundation.org>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded Content Security Policy to include Segment’s CDN for both script and connection sources, aligning with existing analytics endpoints.
  * Reduces potential resource blocking and improves reliability of analytics loading.
  * No changes to runtime behavior or user-facing functionality beyond allowing these resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->