### PR TITLE
fix(auth): prevent infinite loop when third-party cookies are blocked

### DIFF
--- a/src/app/config/app-settings.ts
+++ b/src/app/config/app-settings.ts
@@ -49,4 +49,6 @@ export class AppSettings {
     public static GITLAB_DOMAIN = "gitlab.com";
     public static GITLAB = "Gitlab";
     public static SUPPORT_TICKET_LINK = 'https://jira.linuxfoundation.org/plugins/servlet/theme/portal/4/create/143';
+    public static LOGIN_ATTEMPT_COUNT = 'loginAttemptCount';
+    public static MAX_LOGIN_ATTEMPTS = 3;
 }

--- a/src/app/modules/dashboard/container/cla-dashboard/cla-dashboard.component.ts
+++ b/src/app/modules/dashboard/container/cla-dashboard/cla-dashboard.component.ts
@@ -26,6 +26,7 @@ export class ClaDashboardComponent implements OnInit {
   exitEasyCLA = 'exitEasyCLA';
   hasError: boolean;
   hasPrivateWindow: boolean;
+  hasCookiesBlocked = false;
   project = new ProjectModel();
 
 
@@ -73,10 +74,20 @@ export class ClaDashboardComponent implements OnInit {
       }
     });
 
+    // Subscribe to cookies blocked state
+    this.authService.cookiesBlocked$.subscribe((blocked) => {
+      this.hasCookiesBlocked = blocked;
+      if (blocked) {
+        this.alertService.error(
+          'Authentication failed. Please allow third-party cookies for this site in your browser settings, then refresh the page.'
+        );
+      }
+    });
+
     this.authService.loading$.subscribe((loading) => {
       if (!loading) {
         this.authService.isAuthenticated$.subscribe((authenticated) => {
-          if (!authenticated && !this.hasPrivateWindow) {
+          if (!authenticated && !this.hasPrivateWindow && !this.hasCookiesBlocked) {
             this.authService.login();
           }
         });

--- a/src/app/shared/components/alert/alert.component.scss
+++ b/src/app/shared/components/alert/alert.component.scss
@@ -4,5 +4,5 @@
 .alert {
   left: 0;
   width: 100%;
-  z-index: 1000;
+  margin-bottom: 0;
 }

--- a/src/app/shared/services/auth.service.ts
+++ b/src/app/shared/services/auth.service.ts
@@ -21,6 +21,7 @@ import { LfxAnalyticsService } from './lfx-analytics.service';
 })
 export class AuthService {
   public openCLADialog$ = new BehaviorSubject<any>(false);
+  public cookiesBlocked$ = new BehaviorSubject<boolean>(false);
   auth0Options = {
     domain: EnvConfig.default['auth0-domain'], // e.g linuxfoundation-dev.auth0.com
     clientId: EnvConfig.default['auth0-clientId'],
@@ -109,6 +110,8 @@ export class AuthService {
         this.userProfileSubject$.next(user);
         // Identify user in analytics
         if (user) {
+          // Reset login attempts on successful authentication
+          this.resetLoginAttempts();
           this.analyticsService.identifyAuth0User(user).catch(error => {
             console.error('Failed to identify user in analytics:', error);
           });
@@ -123,6 +126,14 @@ export class AuthService {
   }
 
   login() {
+    // Check if max login attempts reached (prevents infinite loop when cookies are blocked)
+    const attempts = this.getLoginAttemptCount();
+    if (attempts >= AppSettings.MAX_LOGIN_ATTEMPTS) {
+      this.cookiesBlocked$.next(true);
+      return;
+    }
+    this.incrementLoginAttempts();
+
     // Need to increase timeout to 1500 as for slower network it gives an error
     // Cannot read property 'querySelector' of null
     // TODO: verify this still works
@@ -181,6 +192,11 @@ export class AuthService {
     );
   }
 
+  resetLoginAttempts(): void {
+    this.storageService.removeItem(AppSettings.LOGIN_ATTEMPT_COUNT);
+    this.cookiesBlocked$.next(false);
+  }
+
   private async localAuthSetup() {
     // This should only be called on app initialization
     // Set up local authentication streams
@@ -231,6 +247,16 @@ export class AuthService {
       this.login();
       return;
     }
+  }
+
+  private getLoginAttemptCount(): number {
+    const count = this.storageService.getItem(AppSettings.LOGIN_ATTEMPT_COUNT) as string;
+    return count ? parseInt(count, 10) : 0;
+  }
+
+  private incrementLoginAttempts(): void {
+    const currentCount = this.getLoginAttemptCount();
+    this.storageService.setItem(AppSettings.LOGIN_ATTEMPT_COUNT, currentCount + 1);
   }
 
   private getCookie(cname) {


### PR DESCRIPTION
## Summary

Fixes the infinite authentication loop that occurs when third-party cookies are blocked (e.g., Brave Shields, Firefox Enhanced Tracking Protection, Safari ITP).

- Add login attempt tracking with max retry limit (3 attempts)
- Expose `cookiesBlocked$` observable in AuthService
- Show user-friendly error message when cookies are blocked
- Fix alert z-index overlap with header
- Reset login attempts on successful authentication

## Root Cause

When third-party cookies are blocked, Auth0's `getTokenSilently()` fails because it relies on cross-domain cookies for silent authentication. The existing `detectIncognito()` check only identifies private browsing mode, not cookie blocking by browser privacy features.

## Testing

1. Open Brave browser with Shields ON
2. Ensure "Block third-party cookies" is enabled in Advanced controls
3. Navigate to the Contributor Console
4. Attempt to log in
5. Verify: After 3 failed attempts, the loop stops and error message appears

Resolves: https://github.com/linuxfoundation/easycla/issues/4959