### PR TITLE
fix(auth): wait for auth initialization before making API requests

### DIFF
--- a/src/app/shared/services/auth.service.ts
+++ b/src/app/shared/services/auth.service.ts
@@ -29,7 +29,7 @@ export class AuthService {
   };
 
   currentHref = window.location.href;
-  loading$ = new BehaviorSubject<any>(true);
+  loading$ = new BehaviorSubject<boolean>(true);
 
   // Create an observable of Auth0 instance of client
   auth0Client$ = (from(

--- a/src/app/shared/services/interceptor.service.ts
+++ b/src/app/shared/services/interceptor.service.ts
@@ -5,7 +5,7 @@ import {Injectable} from '@angular/core';
 import {HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
 import {AuthService} from './auth.service';
 import {Observable, throwError} from 'rxjs';
-import {catchError, mergeMap} from 'rxjs/operators';
+import {catchError, filter, mergeMap, switchMap, take} from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root',
@@ -15,7 +15,10 @@ export class InterceptorService implements HttpInterceptor {
   }
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    return this.auth.getIdToken$().pipe(
+    return this.auth.loading$.pipe(
+      filter((loading: boolean) => loading === false),
+      take(1),
+      switchMap(() => this.auth.getIdToken$()),
       mergeMap((token) => {
         if (!token) {
           return next.handle(req.clone());


### PR DESCRIPTION
## Summary
- Fix 401 Unauthorized errors that occur immediately after login on DEV environment
- HTTP interceptor now waits for `AuthService.loading$` to emit `false` before attempting to get the token and make requests

## Root Cause
After Auth0 login redirect, API calls to `/v2/user/{userId}` and `/v2/project/{projectId}` were being made before Auth0 was fully initialized, causing the interceptor to send requests without a valid Bearer token.

## Changes
- Updated `interceptor.service.ts` to wait for auth loading to complete before making requests
- Added `filter`, `switchMap`, and `take` RxJS operators to properly sequence the auth check

## Test Plan
1. Navigate to the CLA contributor console
2. Log in via Auth0
3. Log out (click avatar → logout)
4. Log back in
5. Verify: Network tab shows 200 OK on `/v2/user/...` request (no more 401)

Resolves: https://github.com/linuxfoundation/easycla/issues/4989