### PR TITLE
feat: replace Jira support links with Intercom chat

### DIFF
--- a/src/app/config/app-settings.ts
+++ b/src/app/config/app-settings.ts
@@ -37,7 +37,6 @@ export class AppSettings {
     public static GITHUB_EMAIL_CONTENT = 'noreply.github.com';
     public static NEW_ORGANIZATIONS = 'newOrganizations';
     public static LEARN_MORE = 'https://docs.linuxfoundation.org/lfx/easycla/contributors';
-    public static TICKET_URL = 'https://jira.linuxfoundation.org/servicedesk/customer/portal/4/create/143';
     public static LFX_FOOTER = 'lfx-footer';
     public static LFX_HEADER = 'lfx-header-v2';
     public static PROJECT_CONSOLE_LINK_V2 = 'admin-v2-base';
@@ -48,7 +47,6 @@ export class AppSettings {
     public static GITHUB_DOMAIN = "github.com";
     public static GITLAB_DOMAIN = "gitlab.com";
     public static GITLAB = "Gitlab";
-    public static SUPPORT_TICKET_LINK = 'https://jira.linuxfoundation.org/plugins/servlet/theme/portal/4/create/143';
     public static LOGIN_ATTEMPT_COUNT = 'loginAttemptCount';
     public static MAX_LOGIN_ATTEMPTS = 3;
 }

--- a/src/app/modules/corporate-contributor/component/configure-cla-manager-modal/configure-cla-manager-modal.component.ts
+++ b/src/app/modules/corporate-contributor/component/configure-cla-manager-modal/configure-cla-manager-modal.component.ts
@@ -21,7 +21,6 @@ import {
 import { AlertService } from 'src/app/shared/services/alert.service';
 import { UserModel } from 'src/app/core/models/user';
 import { LoaderService } from 'src/app/shared/services/loader.service';
-import { IntercomService } from 'src/app/shared/services/intercom.service';
 
 @Component({
   selector: 'app-configure-cla-manager-modal',
@@ -47,8 +46,7 @@ export class ConfigureClaManagerModalComponent implements OnInit {
     private storageService: StorageService,
     private modalService: NgbModal,
     private alertService: AlertService,
-    private loaderService: LoaderService,
-    private intercomService: IntercomService
+    private loaderService: LoaderService
   ) {
     this.hasCLAManagerDesignee = false;
     this.showCloseBtnEmitter.emit(false);
@@ -257,7 +255,6 @@ export class ConfigureClaManagerModalComponent implements OnInit {
         'Please click on Retry to allow platform more time to assign settings.</br>' +
         'Otherwise please contact support via the chat widget.' +
         ' Once the issue is resolved, you will be able to proceed with the CLA.';
-      this.intercomService.show();
       this.openDialog(this.errorModal);
     }
   }

--- a/src/app/modules/corporate-contributor/component/configure-cla-manager-modal/configure-cla-manager-modal.component.ts
+++ b/src/app/modules/corporate-contributor/component/configure-cla-manager-modal/configure-cla-manager-modal.component.ts
@@ -21,6 +21,7 @@ import {
 import { AlertService } from 'src/app/shared/services/alert.service';
 import { UserModel } from 'src/app/core/models/user';
 import { LoaderService } from 'src/app/shared/services/loader.service';
+import { IntercomService } from 'src/app/shared/services/intercom.service';
 
 @Component({
   selector: 'app-configure-cla-manager-modal',
@@ -46,7 +47,8 @@ export class ConfigureClaManagerModalComponent implements OnInit {
     private storageService: StorageService,
     private modalService: NgbModal,
     private alertService: AlertService,
-    private loaderService: LoaderService
+    private loaderService: LoaderService,
+    private intercomService: IntercomService
   ) {
     this.hasCLAManagerDesignee = false;
     this.showCloseBtnEmitter.emit(false);
@@ -253,10 +255,9 @@ export class ConfigureClaManagerModalComponent implements OnInit {
       this.message =
         'The initial CLA manager settings could not be assigned.</br>' +
         'Please click on Retry to allow platform more time to assign settings.</br>' +
-        'Otherwise you can file a <a href=""' +
-        AppSettings.TICKET_URL +
-        'target="_blank"><b>support ticket</b>.</a>' +
-        ' Once the support ticket is resolved, you will be able to proceed with the CLA.';
+        'Otherwise please contact support via the chat widget.' +
+        ' Once the issue is resolved, you will be able to proceed with the CLA.';
+      this.intercomService.show();
       this.openDialog(this.errorModal);
     }
   }

--- a/src/app/modules/corporate-contributor/component/identify-cla-manager-modal/identify-cla-manager-modal.component.ts
+++ b/src/app/modules/corporate-contributor/component/identify-cla-manager-modal/identify-cla-manager-modal.component.ts
@@ -12,6 +12,7 @@ import { CompanyModel, OrganizationModel } from 'src/app/core/models/organizatio
 import { AlertService } from 'src/app/shared/services/alert.service';
 import { EmailValidator } from 'src/app/shared/validators/email-validator';
 import { AppSettings } from 'src/app/config/app-settings';
+import { IntercomService } from 'src/app/shared/services/intercom.service';
 import { CompanyAdminDesigneeModel, CompnayAdminListModel } from 'src/app/core/models/company-admin-designee';
 
 @Component({
@@ -36,7 +37,8 @@ export class IdentifyClaManagerModalComponent implements OnInit {
     private modalService: NgbModal,
     private claContributorService: ClaContributorService,
     private storageService: StorageService,
-    private alertService: AlertService
+    private alertService: AlertService,
+    private intercomService: IntercomService
   ) {
   }
 
@@ -80,7 +82,7 @@ export class IdentifyClaManagerModalComponent implements OnInit {
   }
 
   onClickSupporticket() {
-    window.open(AppSettings.SUPPORT_TICKET_LINK, '_blank');
+    this.intercomService.show();
   }
 
   addNewOrganization(data) {

--- a/src/app/modules/corporate-contributor/container/corporate-dashboard/corporate-dashboard.component.ts
+++ b/src/app/modules/corporate-contributor/container/corporate-dashboard/corporate-dashboard.component.ts
@@ -22,6 +22,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { AlertService } from 'src/app/shared/services/alert.service';
 import { ProjectModel } from 'src/app/core/models/project';
 import { AppSettings } from 'src/app/config/app-settings';
+import { IntercomService } from 'src/app/shared/services/intercom.service';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -69,7 +70,8 @@ export class CorporateDashboardComponent implements OnInit, OnDestroy {
     private location: PlatformLocation,
     private storageService: StorageService,
     private formBuilder: FormBuilder,
-    private alertService: AlertService
+    private alertService: AlertService,
+    private intercomService: IntercomService
   ) {
     this.projectId = this.route.snapshot.paramMap.get('projectId');
     this.userId = this.route.snapshot.paramMap.get('userId');
@@ -191,8 +193,8 @@ export class CorporateDashboardComponent implements OnInit, OnDestroy {
         }else {
           this.message =
             `We're sorry, you are currently unable to acknowledge the Employee Contributor License Agreement (ECLA) for this organization.
-             If you believe this may be an error, please contact
-             <a href="https://jira.linuxfoundation.org/plugins/servlet/desk/portal/4/create/143" target="_blank">EasyCLA Support</a>`;
+             If you believe this may be an error, please contact EasyCLA Support via the chat widget.`;
+          this.intercomService.show();
           this.openWithDismiss(this.warningModal);
         }
         },
@@ -204,12 +206,11 @@ export class CorporateDashboardComponent implements OnInit, OnDestroy {
             'The selected company ' +
             companyName +
             ' has not been fully setup.</br>' +
-            ' Please help us by <a href="' +
-            AppSettings.TICKET_URL +
-            '" target="_blank">filing a support ticket</a>' +
+            ' Please contact support via the chat widget' +
             ' to get the Organization Administrator assigned. Once the Organization Administrator is assigned to ' +
             companyName +
             ' you will be able to proceed with the CLA.';
+          this.intercomService.show();
           this.openWithDismiss(this.warningModal);
         }
       );

--- a/src/app/modules/corporate-contributor/container/corporate-dashboard/corporate-dashboard.component.ts
+++ b/src/app/modules/corporate-contributor/container/corporate-dashboard/corporate-dashboard.component.ts
@@ -22,6 +22,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { AlertService } from 'src/app/shared/services/alert.service';
 import { ProjectModel } from 'src/app/core/models/project';
 import { AppSettings } from 'src/app/config/app-settings';
+import { IntercomService } from 'src/app/shared/services/intercom.service';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -69,7 +70,8 @@ export class CorporateDashboardComponent implements OnInit, OnDestroy {
     private location: PlatformLocation,
     private storageService: StorageService,
     private formBuilder: FormBuilder,
-    private alertService: AlertService
+    private alertService: AlertService,
+    private intercomService: IntercomService
   ) {
     this.projectId = this.route.snapshot.paramMap.get('projectId');
     this.userId = this.route.snapshot.paramMap.get('userId');
@@ -193,6 +195,7 @@ export class CorporateDashboardComponent implements OnInit, OnDestroy {
             `We're sorry, you are currently unable to acknowledge the Employee Contributor License Agreement (ECLA) for this organization.
              If you believe this may be an error, please contact EasyCLA Support via the chat widget.`;
           this.openWithDismiss(this.warningModal);
+          this.intercomService.show();
         }
         },
         () => {
@@ -208,6 +211,7 @@ export class CorporateDashboardComponent implements OnInit, OnDestroy {
             companyName +
             ' you will be able to proceed with the CLA.';
           this.openWithDismiss(this.warningModal);
+          this.intercomService.show();
         }
       );
   }

--- a/src/app/modules/corporate-contributor/container/corporate-dashboard/corporate-dashboard.component.ts
+++ b/src/app/modules/corporate-contributor/container/corporate-dashboard/corporate-dashboard.component.ts
@@ -22,7 +22,6 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { AlertService } from 'src/app/shared/services/alert.service';
 import { ProjectModel } from 'src/app/core/models/project';
 import { AppSettings } from 'src/app/config/app-settings';
-import { IntercomService } from 'src/app/shared/services/intercom.service';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -70,8 +69,7 @@ export class CorporateDashboardComponent implements OnInit, OnDestroy {
     private location: PlatformLocation,
     private storageService: StorageService,
     private formBuilder: FormBuilder,
-    private alertService: AlertService,
-    private intercomService: IntercomService
+    private alertService: AlertService
   ) {
     this.projectId = this.route.snapshot.paramMap.get('projectId');
     this.userId = this.route.snapshot.paramMap.get('userId');
@@ -194,7 +192,6 @@ export class CorporateDashboardComponent implements OnInit, OnDestroy {
           this.message =
             `We're sorry, you are currently unable to acknowledge the Employee Contributor License Agreement (ECLA) for this organization.
              If you believe this may be an error, please contact EasyCLA Support via the chat widget.`;
-          this.intercomService.show();
           this.openWithDismiss(this.warningModal);
         }
         },
@@ -210,7 +207,6 @@ export class CorporateDashboardComponent implements OnInit, OnDestroy {
             ' to get the Organization Administrator assigned. Once the Organization Administrator is assigned to ' +
             companyName +
             ' you will be able to proceed with the CLA.';
-          this.intercomService.show();
           this.openWithDismiss(this.warningModal);
         }
       );

--- a/src/app/modules/individual-contributor/container/individual-dashboard/individual-dashboard.component.ts
+++ b/src/app/modules/individual-contributor/container/individual-dashboard/individual-dashboard.component.ts
@@ -9,6 +9,7 @@ import { ActiveSignatureModel } from 'src/app/core/models/active-signature';
 import { IndividualRequestSignatureModel } from 'src/app/core/models/individual-request-signature';
 import { StorageService } from 'src/app/shared/services/storage.service';
 import { AppSettings } from 'src/app/config/app-settings';
+import { IntercomService } from 'src/app/shared/services/intercom.service';
 
 @Component({
   selector: 'app-individual-dashboard',
@@ -28,7 +29,8 @@ export class IndividualDashboardComponent implements OnInit {
     private router: Router,
     private claContributorService: ClaContributorService,
     private alertService: AlertService,
-    private storageService: StorageService
+    private storageService: StorageService,
+    private intercomService: IntercomService
   ) {
     this.projectId = this.route.snapshot.paramMap.get('projectId');
     this.userId = this.route.snapshot.paramMap.get('userId');
@@ -80,6 +82,7 @@ export class IndividualDashboardComponent implements OnInit {
         } else {
           this.status = 'Incomplete';
           this.alertService.error('CLA system is not able to support your request. Please contact support via the chat widget.');
+          this.intercomService.show();
         }
       },
       (exception) => {

--- a/src/app/modules/individual-contributor/container/individual-dashboard/individual-dashboard.component.ts
+++ b/src/app/modules/individual-contributor/container/individual-dashboard/individual-dashboard.component.ts
@@ -9,7 +9,6 @@ import { ActiveSignatureModel } from 'src/app/core/models/active-signature';
 import { IndividualRequestSignatureModel } from 'src/app/core/models/individual-request-signature';
 import { StorageService } from 'src/app/shared/services/storage.service';
 import { AppSettings } from 'src/app/config/app-settings';
-import { IntercomService } from 'src/app/shared/services/intercom.service';
 
 @Component({
   selector: 'app-individual-dashboard',
@@ -29,8 +28,7 @@ export class IndividualDashboardComponent implements OnInit {
     private router: Router,
     private claContributorService: ClaContributorService,
     private alertService: AlertService,
-    private storageService: StorageService,
-    private intercomService: IntercomService
+    private storageService: StorageService
   ) {
     this.projectId = this.route.snapshot.paramMap.get('projectId');
     this.userId = this.route.snapshot.paramMap.get('userId');
@@ -82,7 +80,6 @@ export class IndividualDashboardComponent implements OnInit {
         } else {
           this.status = 'Incomplete';
           this.alertService.error('CLA system is not able to support your request. Please contact support via the chat widget.');
-          this.intercomService.show();
         }
       },
       (exception) => {

--- a/src/app/modules/individual-contributor/container/individual-dashboard/individual-dashboard.component.ts
+++ b/src/app/modules/individual-contributor/container/individual-dashboard/individual-dashboard.component.ts
@@ -9,6 +9,7 @@ import { ActiveSignatureModel } from 'src/app/core/models/active-signature';
 import { IndividualRequestSignatureModel } from 'src/app/core/models/individual-request-signature';
 import { StorageService } from 'src/app/shared/services/storage.service';
 import { AppSettings } from 'src/app/config/app-settings';
+import { IntercomService } from 'src/app/shared/services/intercom.service';
 
 @Component({
   selector: 'app-individual-dashboard',
@@ -28,7 +29,8 @@ export class IndividualDashboardComponent implements OnInit {
     private router: Router,
     private claContributorService: ClaContributorService,
     private alertService: AlertService,
-    private storageService: StorageService
+    private storageService: StorageService,
+    private intercomService: IntercomService
   ) {
     this.projectId = this.route.snapshot.paramMap.get('projectId');
     this.userId = this.route.snapshot.paramMap.get('userId');
@@ -79,10 +81,8 @@ export class IndividualDashboardComponent implements OnInit {
           this.status = 'Completed';
         } else {
           this.status = 'Incomplete';
-          let error = 'CLA system is not able to support your request. Please ';
-          error += '<a href="https://jira.linuxfoundation.org/servicedesk/customer/portal/4" style="color:#0099cc" target="_blank">create a ticket</a>';
-          error += ' to help us resolve this issue';
-          this.alertService.error(error);
+          this.alertService.error('CLA system is not able to support your request. Please contact support via the chat widget.');
+          this.intercomService.show();
         }
       },
       (exception) => {

--- a/src/app/shared/services/lfx-header.service.ts
+++ b/src/app/shared/services/lfx-header.service.ts
@@ -16,6 +16,7 @@ export class LfxHeaderService {
     this.setUserInLFxHeader();
     this.setLinks();
     this.setCallBackUrl();
+    this.setSupportClickHandler();
   }
 
   setLinks() {
@@ -42,6 +43,18 @@ export class LfxHeaderService {
     if (lfHeaderEl) {
       lfHeaderEl.callbackurl = this.auth.auth0Options.callbackUrl;
     }
+  }
+
+  setSupportClickHandler(): void {
+    const lfHeaderEl: any = document.getElementById('lfx-header-v2');
+    if (!lfHeaderEl) {
+      return;
+    }
+    lfHeaderEl.onsupportclick = () => {
+      if (window.Intercom) {
+        window.Intercom('show');
+      }
+    };
   }
 
   setUserInLFxHeader(): void {

--- a/src/index.html
+++ b/src/index.html
@@ -28,7 +28,6 @@
     <lfx-header-v2
       product="LF CLA"
       id="lfx-header-v2"
-      supportlink="https://jira.linuxfoundation.org/plugins/servlet/theme/portal/4/create/143"
       docslink="https://docs.linuxfoundation.org/lfx/easycla/v2-current"
       faqlink="https://docs.linuxfoundation.org/lfx/easycla/v2-current/getting-started/easycla-faqs"
     >


### PR DESCRIPTION
## Summary

- Removes the static `supportlink` Jira URL from `<lfx-header-v2>` in `index.html`; adds `onsupportclick` handler in `LfxHeaderService` that opens the Intercom chat widget
- Replaces all in-app Jira support ticket links with Intercom
- Removes `TICKET_URL` and `SUPPORT_TICKET_LINK` Jira constants from `AppSettings`

Affected components:
- `identify-cla-manager-modal` — support ticket button now opens Intercom
- `configure-cla-manager-modal` — role assignment failure error message directs to chat widget (Retry is the primary action)
- `corporate-dashboard` — sanctioned org and company not set up errors open Intercom automatically (user is fully blocked, no alternative action)
- `individual-dashboard` — CLA signature failure opens Intercom automatically (user is fully blocked)

## Test plan

- [ ] Click "Support" in the LFX header — Intercom chat widget opens
- [ ] Trigger the sanctioned org error in corporate flow — modal appears and Intercom opens automatically
- [ ] Trigger the company not set up error in corporate flow — modal appears and Intercom opens automatically
- [ ] Trigger the CLA manager role assignment failure — error message references chat widget; Intercom does not auto-open (Retry is available)
- [ ] Click the support link in identify-CLA-manager modal — Intercom opens
- [ ] Trigger the individual CLA signature failure — error message appears and Intercom opens automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)
