### PR TITLE
fix: wire onsupportclick in setLinks() so Support item appears in header

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,11 +1,12 @@
 // Copyright The Linux Foundation and each contributor to CommunityBridge.
 // SPDX-License-Identifier: MIT
 
-import { Component, OnDestroy } from '@angular/core';
+import { AfterViewInit, Component, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { AuthService } from './shared/services/auth.service';
 import { IntercomService } from './shared/services/intercom.service';
+import { LfxHeaderService } from './shared/services/lfx-header.service';
 import { ActivatedRoute } from '@angular/router';
 
 @Component({
@@ -13,7 +14,7 @@ import { ActivatedRoute } from '@angular/router';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class AppComponent implements OnDestroy {
+export class AppComponent implements AfterViewInit, OnDestroy {
   title = 'easycla-contributor-console';
   hasExpanded: boolean;
   links: any[];
@@ -24,8 +25,13 @@ export class AppComponent implements OnDestroy {
   constructor(
     private auth: AuthService,
     private intercomService: IntercomService,
+    private lfxHeaderService: LfxHeaderService,
     private route: ActivatedRoute
   ) {}
+
+  ngAfterViewInit() {
+    this.lfxHeaderService.setSupportClickHandler();
+  }
 
   onToggled() {
     this.hasExpanded = !this.hasExpanded;

--- a/src/app/shared/services/lfx-header.service.ts
+++ b/src/app/shared/services/lfx-header.service.ts
@@ -35,7 +35,14 @@ export class LfxHeaderService {
     ];
     const element: any = document.getElementById('lfx-header-v2');
     element.links = this.links;
-    element.onsupportclick = () => {
+  }
+
+  setSupportClickHandler(): void {
+    const lfHeaderEl: any = document.getElementById('lfx-header-v2');
+    if (!lfHeaderEl) {
+      return;
+    }
+    lfHeaderEl.onsupportclick = () => {
       if (window.Intercom) {
         window.Intercom('show');
       }

--- a/src/app/shared/services/lfx-header.service.ts
+++ b/src/app/shared/services/lfx-header.service.ts
@@ -34,6 +34,9 @@ export class LfxHeaderService {
       },
     ];
     const element: any = document.getElementById('lfx-header-v2');
+    if (!element) {
+      return;
+    }
     element.links = this.links;
   }
 

--- a/src/app/shared/services/lfx-header.service.ts
+++ b/src/app/shared/services/lfx-header.service.ts
@@ -16,7 +16,6 @@ export class LfxHeaderService {
     this.setUserInLFxHeader();
     this.setLinks();
     this.setCallBackUrl();
-    this.setSupportClickHandler();
   }
 
   setLinks() {
@@ -36,6 +35,11 @@ export class LfxHeaderService {
     ];
     const element: any = document.getElementById('lfx-header-v2');
     element.links = this.links;
+    element.onsupportclick = () => {
+      if (window.Intercom) {
+        window.Intercom('show');
+      }
+    };
   }
 
   setCallBackUrl() {
@@ -43,18 +47,6 @@ export class LfxHeaderService {
     if (lfHeaderEl) {
       lfHeaderEl.callbackurl = this.auth.auth0Options.callbackUrl;
     }
-  }
-
-  setSupportClickHandler(): void {
-    const lfHeaderEl: any = document.getElementById('lfx-header-v2');
-    if (!lfHeaderEl) {
-      return;
-    }
-    lfHeaderEl.onsupportclick = () => {
-      if (window.Intercom) {
-        window.Intercom('show');
-      }
-    };
   }
 
   setUserInLFxHeader(): void {


### PR DESCRIPTION
## Summary

Fixes missing "Support" item in the LFX header help menu by calling `setSupportClickHandler()` from `ngAfterViewInit` instead of the service constructor.

## Root cause

`setSupportClickHandler()` was being called from `LfxHeaderService`'s constructor, which runs before Angular initializes the view. At that point `getElementById('lfx-header-v2')` returns `null` and the handler is never set.

The fix mirrors the pattern in `easycla-landing-page`, which calls `setSupportClickHandler()` from `AppComponent.ngAfterViewInit()` — the correct lifecycle hook for DOM-dependent setup.

## Changes

- `app.component.ts`: implement `AfterViewInit`, inject `LfxHeaderService`, call `setSupportClickHandler()` from `ngAfterViewInit()`
- `lfx-header.service.ts`: restore `setSupportClickHandler()` as a standalone method (reverts the previous incorrect fix that placed `onsupportclick` inside `setLinks()`)

## Test plan

- [ ] Open the app and click the `?` help icon in the LFX header — verify "Support" item appears alongside "Docs" and "FAQ"
- [ ] Click "Support" — verify Intercom chat widget opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
