### PR TITLE
fix(routing): register #/auth route so Auth0 callback resolves correctly (#502)

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -19,6 +19,11 @@ const routes: Routes = [
     component: AuthDashboardComponent
   },
   {
+    path: 'auth',
+    pathMatch: 'full',
+    component: AuthDashboardComponent
+  },
+  {
     path: 'cla/project/:projectId/user/:userId',
     pathMatch: 'full',
     component: ClaDashboardComponent

--- a/src/app/modules/dashboard/container/auth-dashboard/auth-dashboard.component.spec.ts
+++ b/src/app/modules/dashboard/container/auth-dashboard/auth-dashboard.component.spec.ts
@@ -2,27 +2,64 @@
 // SPDX-License-Identifier: MIT
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
 
+import { AppSettings } from 'src/app/config/app-settings';
+import { StorageService } from 'src/app/shared/services/storage.service';
 import { AuthDashboardComponent } from './auth-dashboard.component';
 
 describe('AuthDashboardComponent', () => {
   let component: AuthDashboardComponent;
   let fixture: ComponentFixture<AuthDashboardComponent>;
+  let routerSpy: jasmine.SpyObj<Router>;
+  let storageSpy: jasmine.SpyObj<StorageService>;
 
   beforeEach(async () => {
+    routerSpy = jasmine.createSpyObj<Router>('Router', ['navigate']);
+    storageSpy = jasmine.createSpyObj<StorageService>('StorageService', ['getItem']);
+    storageSpy.getItem.and.returnValue(null);
+
     await TestBed.configureTestingModule({
-      declarations: [ AuthDashboardComponent ]
-    })
-    .compileComponents();
+      declarations: [AuthDashboardComponent],
+      providers: [
+        { provide: Router, useValue: routerSpy },
+        { provide: StorageService, useValue: storageSpy }
+      ]
+    }).compileComponents();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AuthDashboardComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
+  });
+
+  it('navigates to /cla/project/:projectId/user/:userId with redirect query param on init', () => {
+    storageSpy.getItem.and.callFake(((key: string) => {
+      switch (key) {
+        case AppSettings.PROJECT_ID:
+          return JSON.stringify('proj-123');
+        case AppSettings.USER_ID:
+          return JSON.stringify('user-456');
+        case AppSettings.REDIRECT:
+          return JSON.stringify('https://github.com/foo/bar/pull/42');
+        default:
+          return null;
+      }
+    }) as <T>(key: string) => T);
+
+    fixture.detectChanges();
+
+    expect(storageSpy.getItem).toHaveBeenCalledWith(AppSettings.PROJECT_ID);
+    expect(storageSpy.getItem).toHaveBeenCalledWith(AppSettings.USER_ID);
+    expect(storageSpy.getItem).toHaveBeenCalledWith(AppSettings.REDIRECT);
+    expect(routerSpy.navigate).toHaveBeenCalledOnceWith(
+      ['/cla/project/proj-123/user/user-456'],
+      { queryParams: { redirect: 'https://github.com/foo/bar/pull/42' } }
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Adds the missing `auth` route in `app-routing.module.ts` mapped to
  `AuthDashboardComponent` so the Auth0 post-login redirect to
  `${origin}/#/auth` resolves correctly instead of falling through to the
  `**` wildcard and rendering `PageNotFoundComponent`.
- Strengthens the `AuthDashboardComponent` unit test with `Router` /
  `StorageService` spies and adds a regression test asserting the
  storage-driven navigation that the new route now runs.

Closes linuxfoundation/easycla-contributor-console#502.
Tracked in linuxfoundation/easycla#5032 (mirror issue for commit-msg hook).

## Why

`auth.service.ts` configures Auth0's `callbackUrl` as
`${window.location.origin}/#/auth`, but only `path: ''` was registered for
`AuthDashboardComponent`. With `useHash: true`, `#/auth` matched neither
`''` nor any other route → wildcard → `PageNotFoundComponent`, so
`AuthDashboardComponent.ngOnInit` (which reads `PROJECT_ID` / `USER_ID` /
`REDIRECT` from `localStorage` and routes the user back into the CLA flow)
never ran after the Auth0 callback. See
linuxfoundation/easycla-contributor-console#502 for the full root-cause
write-up. Adding the route is the fix the issue recommends; it requires no
Auth0 tenant config changes.

## Test plan

- [x] Lint clean (`eslint './src/**/*.ts' --quiet`).
- [x] Unit tests: `AuthDashboardComponent` suite passes; existing skeleton
      `should create` test fixed as a side effect of the new mocks. Suite
      went from `10 FAILED, 23 SUCCESS` on `main` → `9 FAILED, 24 SUCCESS`;
      remaining 9 failures are pre-existing `should create` stubs in
      unrelated services, unchanged by this PR.
- [x] Local `ng serve` + Playwright:
  - Pre-fix repro (route removed via hot-reload) → "Page Not Found" at
    `#/auth`, matches the issue's screenshot.
  - Post-fix → `#/auth` with `projectId` / `userId` / `redirect` in
    `localStorage` redirects to
    `#/cla/project/<projectId>/user/<userId>?redirect=...` and renders the
    "What type of contributor are you?" screen.
  - No regression on `#/` (still resolves through `AuthDashboardComponent`).
- [ ] Post-merge DEV check: re-run the original #502 repro end-to-end
      (sign-link → login → header-menu Logout → re-paste sign-link →
      re-login) against `easycla.dev.communitybridge.org`.